### PR TITLE
Fix stv election

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *__pycache__
+dist/
+psifospoll.egg-info

--- a/main.py
+++ b/main.py
@@ -4,17 +4,17 @@ from psifospoll import STVElection
 def stvTally(s, candidates_list, ballot_list):
     election = STVElection()
     election.runElection(s, candidates_list, ballot_list)
-    print(election.getRoundResumes())
-    print(election.getTalliesResumes())
-    print(election.getWinnersList())
+    print('round resumes', election.getRoundResumes())
+    print('tallies resumes', election.getTalliesResumes())
+    print('winners list', election.getWinnersList())
+    print('quota', election.getQuota())
 
 
 l1 = [
     [1, 2, 3, 4, 5],
-    [5, 4, 3, 2, 1],
-    [2, 3, 4, 5, 1],
-    [3, 4, 5, 1, 2],
-    [4, 5, 1, 2, 3],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
     [1, 2, 3, 4, 5],
 ]
 cand = [1, 2, 3, 4, 5]

--- a/psifospoll/elections/STVElection.py
+++ b/psifospoll/elections/STVElection.py
@@ -8,6 +8,7 @@ class STVElection(Election):
         self.round_resumes = []
         self.tallies_resumes = []
         self.winners_list = []
+        self.quota = None
 
     def getRoundResumes(self):
         return self.round_resumes
@@ -18,10 +19,18 @@ class STVElection(Election):
     def getWinnersList(self):
         return self.winners_list
 
+    def getQuota(self):
+        return self.quota
+    
+    def setQuota(self, new_value):
+        global quota
+        self.quota = new_value
+
     def runElection(self, s, candidates_list, ballot_list):
         global round_resumes, tallies_resumes, winners_list
         stv = STVTally(s, candidates_list, ballot_list)
         open_seats = s
+        self.setQuota(stv.q)
 
         while len(stv.round_resume["hopeful"]) > open_seats and open_seats > 0:
             stv.computeFirstPreferenceTallies()

--- a/psifospoll/elections/tallies/STVtally.py
+++ b/psifospoll/elections/tallies/STVtally.py
@@ -28,7 +28,7 @@ class STVTally(Tally):
         self.candidates_and_tallies = defaultdict(int)
         for ballot in self.ballot_list:
             preferences_list = ballot.preferences_list
-            if len(preferences_list) > 0:
+            if len(preferences_list) > 0 and ballot.weight > 0:
                 first_preference = preferences_list[0]
                 self.candidates_and_tallies[first_preference] += ballot.weight
         self.candidates_and_tallies = dict(self.candidates_and_tallies)
@@ -38,7 +38,7 @@ class STVTally(Tally):
         tallies_and_candidates = invertDict(self.candidates_and_tallies)
         tallies = list(tallies_and_candidates.keys())
 
-        elected_tallies = list(filter(lambda x: x > self.q, tallies))
+        elected_tallies = list(filter(lambda x: x >= self.q, tallies))
         elected_candidates = [
             candidate
             for tally in elected_tallies

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="psifospoll",
-    version="1.0.1",
+    version="1.0.2",
     author="Fernanda Macías",
     author_email="fernanda.macias@ug.uchile.cl",
     description="PsifosPoll is a python library for different voting methods",


### PR DESCRIPTION
# BUG
## Repro
- Ingresar al archivo main  con tres puestos disponibles las siguientes papeletas
[
    [0, 1, 2, 3, 4, 5],
    [0, 1, 2, 3, 4],
    [0, 1, 2, 3],
    [0, 1, 2],
]
- Observar el tallies resumes
## Esperado
Obtener [{0: 4}, {1: 2.0}, {}, {}, {}]

## Bug
Se otiene  [{0: 4}, {1: 2.0}, {1: 2.0}, {1: 2.0}, {1: 2.0}]

# Problema
El criterio para declarar electo a alguien es tally > q, pero debiera ser tally >= q.
Los tally = 0 no deben aparecer en el tally resume.